### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/DateTime/TimeZone.pm6
+++ b/lib/DateTime/TimeZone.pm6
@@ -1,4 +1,4 @@
-module DateTime::TimeZone;
+unit module DateTime::TimeZone;
 
 ## An app-facing set of friendly subroutines for working with timezones.
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.