### PR TITLE
Make gen-tzdata-classes.pl run with current Rakudo

### DIFF
--- a/tools/gen-tzdata-classes.pl6
+++ b/tools/gen-tzdata-classes.pl6
@@ -182,7 +182,7 @@ sub MAIN($tzdata-file, $output-dir) {
                 }
                 @zonedata.push($data);
             }
-            @rules = uniq sort @rules;
+            @rules = unique sort @rules;
             $fh.say('has %.rules = ( ');
             for @rules -> $rule {
                 $fh.say(" $rule => " ~ %ruledata{$rule}.perl ~ ",");

--- a/tools/gen-tzdata-classes.pl6
+++ b/tools/gen-tzdata-classes.pl6
@@ -108,7 +108,7 @@ sub MAIN($tzdata-file, $output-dir) {
             my $name = ~$zone<name>;
             $name ~~ s:g/\+/_plus_/;
             $name ~~ s:g/\-/_minus_/;
-            my $dir = ($output-dir ~ $name ~ ".pm6").path.directory;
+            my $dir = ($output-dir ~ $name ~ ".pm6").IO.dirname;
             while !($dir.IO ~~ :d) {
                 @dirs_to_make.unshift($dir);
                 $dir = $dir.path.parent;
@@ -201,7 +201,7 @@ sub MAIN($tzdata-file, $output-dir) {
             $new-tz ~~ s:g/\-/_minus_/;
 
             my @dirs_to_make;
-            my $dir = ($output-dir ~ $old-tz ~ ".pm6").path.directory;
+            my $dir = ($output-dir ~ $old-tz ~ ".pm6").IO.dirname;
             while !($dir.IO ~~ :d) {
                 @dirs_to_make.unshift($dir);
                 $dir = $dir.path.parent;

--- a/tools/gen-tzdata-classes.pl6
+++ b/tools/gen-tzdata-classes.pl6
@@ -72,9 +72,9 @@ sub MAIN($tzdata-file, $output-dir) {
     if $parsed {
         say "parsed";
         my %ruledata;
-        my @rules = $parsed<rule>;
-        my @zones = $parsed<zone>;
-        my @links = $parsed<link>;
+        my @rules := $parsed<rule>;
+        my @zones := $parsed<zone>;
+        my @links := $parsed<link>;
         my $x = 0;
         say +@rules ~ " rules";
         say +@zones ~ " zones";
@@ -125,7 +125,7 @@ sub MAIN($tzdata-file, $output-dir) {
             $fh.say("class DateTime::TimeZone::Zone::" ~ $classname ~ " does DateTime::TimeZone::Zone;");
 
             my @rules;
-            my @zoneentries = $zone<zonedata>;
+            my @zoneentries := $zone<zonedata>;
             my @zonedata;
             for @zoneentries -> $zoneentry {
                 my $rule = "";

--- a/tools/gen-tzdata-classes.pl6
+++ b/tools/gen-tzdata-classes.pl6
@@ -33,7 +33,7 @@ grammar TZData {
     token gmtoff { \S+ }
     token rules { \S+ }
     token format { \S+ }
-    token until { <-['#'\n]>+ }
+    token until { <-[#\n]>+ }
     token new-tz { \S+ }
     token old-tz { \S+ }
 }


### PR DESCRIPTION
While updating the code to use the new `unit` descriptor, I found that the script `gen-tzdata-classes.pl` didn't run with the current Rakudo (2015.05).  These changes bring the script up to date so that one can update the generated timezone classes.